### PR TITLE
Updated for grits-net-mapper changes

### DIFF
--- a/example/.meteor/packages
+++ b/example/.meteor/packages
@@ -8,4 +8,3 @@ meteor-platform
 insecure
 grits:grits-net-meteor
 coffeescript
-grits:grits-net-mapper

--- a/example/.meteor/versions
+++ b/example/.meteor/versions
@@ -14,7 +14,7 @@ ejson@1.0.6
 fastclick@1.0.3
 fuatsengul:leaflet@1.0.1
 geojson-utils@1.0.3
-grits:grits-net-mapper@0.0.1
+grits:grits-net-mapper@0.2.2
 grits:grits-net-meteor@0.0.1
 html-tools@1.0.4
 htmljs@1.0.4
@@ -55,4 +55,3 @@ underscore@1.0.3
 url@1.0.4
 webapp@1.2.0
 webapp-hashing@1.0.3
-yauh:turfjs-client@0.0.2

--- a/package.js
+++ b/package.js
@@ -8,11 +8,12 @@ Package.on_use(function(api){
   api.use([
     'coffeescript',
     'mongo',
+    'fuatsengul:leaflet@1.0.1',
     'jagi:astronomy@0.12.0',
     'jagi:astronomy-validators@0.10.8',
     'mizzao:autocomplete@0.5.1',
     'peerlibrary:async@0.9.2_1',
-    'grits:grits-net-mapper'
+    'grits:grits-net-mapper@0.2.2'
   ]);
   api.use([
     'underscore',


### PR DESCRIPTION
This brings `grits-net-meteor` up to date with `grits-net-mapper`'s `pseudo-master` branch.
