### PR TITLE
Using master branch instead test/fix branches

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,10 @@
 checkout:
   post:
     - mkdir example/packages
-    - git clone git@github.com:ecohealthalliance/grits-net-meteor.git && cd grits-net-meteor && git checkout test:
+    - git clone git@github.com:ecohealthalliance/grits-net-meteor.git && cd grits-net-meteor:
         pwd:
           example/packages
-    - git clone git@github.com:ecohealthalliance/grits-net-mapper.git && cd grits-net-mapper && git checkout ci-fix:
+    - git clone git@github.com:ecohealthalliance/grits-net-mapper.git && cd grits-net-mapper:
         pwd:
           example/packages
 dependencies:


### PR DESCRIPTION
CircleCI tests are expected to fail, currently. They will settle once https://github.com/ecohealthalliance/grits-net-mapper/pull/13 and https://github.com/ecohealthalliance/grits-net-meteor/pull/19 are merged.
