### PR TITLE
Updated the heatmap css to keep it behind the path and node svg layers

### DIFF
--- a/client/stylesheets/main.styl
+++ b/client/stylesheets/main.styl
@@ -234,4 +234,7 @@ thead, tbody tr
   font-style italic
 
 .activeRow
-  background-color #d9fafe  
+  background-color #d9fafe
+
+.leaflet-heatmap-layer
+  z-index -1


### PR DESCRIPTION
Neither L.heatLayer nor L.d3SvgOverlay have a configurable z-index option.

The heatmap canvas can be moved behind the path and node layers by prepending it to leaflet-overlay-pane using: 

`$(".leaflet-overlay-pane").prepend($(".leaflet-heatmap-layer"))`

However, specifying the z-index in the css definition of leaflet-heatmap-layer is less evasive
