### PR TITLE
Merge #109285804 fix typeahead keyboard nav into pseudo-master

### DIFF
--- a/client/templates/grits_filter.coffee
+++ b/client/templates/grits_filter.coffee
@@ -7,6 +7,7 @@ _lastFlightId = null # stores the last flight _id from the collection, used in l
 _departureSearchMain = null # onRendered will set this to a typeahead object
 _departureSearch = null # onRendered will set this to a typeahead object
 _arrivalSearch = null # onRendered will set this to a typeahead object
+_suggestionTemplate = _.template('<span><%= obj.field %>: <%= obj.value %> (<%= obj.airport.get("_id") %> - <%= obj.airport.get("name") %>)</span>')
 
 _typeaheadMatcher =
   WAC: {weight: 0, regexOpt: 'ig'}


### PR DESCRIPTION
fixes 109285804 populate input with HTML

Launch the app, type something into the search input and use keyboard navigation keys.  The input should not be populated with HTML tags.
- removed the html from being assigned to the value.
- added reference to the airport document to be used by the typeahead
  template
- added options {hint: false, highlight: true} to the typeahead(s)
- added custom template for suggestion (used _.template as its already included
  by meteor)

see: https://github.com/twitter/typeahead.js/blob/master/doc/jquery_typeahead.md#options
