### PR TITLE
fix #109294314 typeahead hidden by flightTable (z-index)

### DIFF
--- a/client/stylesheets/main.styl
+++ b/client/stylesheets/main.styl
@@ -110,6 +110,15 @@ body
 	width 36px
 	height 36px
 
+.leaflet-top.leaflet-left
+  z-index 1004
+.leaflet-top.leaflet-right
+  z-index 1003
+.leaflet-bottom.leaflet-left
+  z-index 1002
+.leaflet-bottom.leaflet-right
+  z-index 1001
+
 #mapLegendPanel
 	width 180px
 


### PR DESCRIPTION
leaflet defaults all four corner control containers to zindex of 1000.

Now z-index is specified from higher to lower in our stylesheet:
top left control container
top right control container
bottom left control container
bottom right control container
