### PR TITLE
Fix for stops event handler to prevent loading indicator when nothing changes.

### DIFF
--- a/client/grits_filter_criteria.coffee
+++ b/client/grits_filter_criteria.coffee
@@ -600,15 +600,7 @@ class GritsFilterCriteria
     if _.isUndefined(value)
       throw new Error('A value must be defined or null.')
     # the call to change did not come from the UI
-    if _.isEqual(self.stops.get(), {value: value, operator: operator})
-      # the reactive var is already set, change is from the UI
-      if _.isNull(value)
-        self.remove('stops')
-      else
-        self.createOrUpdate('stops', {key: 'stops', operator: operator, value: value, operator2: operator2, value2: value2})
-    else
-      self.stops.set({'value': value, 'operator': operator})
-      $('#stopsOperator').val(operator)
+    self.createOrUpdate('stops', {key: 'stops', operator: operator, value: value, operator2: operator2, value2: value2})
     return
   trackStops: () ->
     self = this


### PR DESCRIPTION
- Fixed error in the stops event handler that was causing the error @dan-nyanko found.  Per his suggestion to display filterLoading on Session.get('grits-net-meteor:isUpdating'), there is a delay in the autorun function that makes the loading indicator seem to lag behind slider update.  
