### PR TITLE
Update the search box typeahead to make airport code take precedence.

### DIFF
--- a/client/templates/grits_search_and_advanced_filtration.coffee
+++ b/client/templates/grits_search_and_advanced_filtration.coffee
@@ -151,8 +151,6 @@ _determineFieldMatchesByWeight = (input, res) ->
             match.display = matcher.display
   if Meteor.gritsUtil.debug
     console.log('matches:', matches)
-  if matches.length > 0
-    return matches.sort(compare)
   return matches
 
 # resets the simuationProgress

--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -1,8 +1,8 @@
-Future = Npm.require('fibers/future');
+Future = Npm.require('fibers/future')
 
 _FLIRT_SIMULATOR_URL = process.env.FLIRT_SIMULATOR_URL
 if _FLIRT_SIMULATOR_URL == ''
-  throw new Error('You must set FLIRT_SIMULATOR_URL environment variable, ex: http://localhost:45000/simulator');
+  throw new Error('You must set FLIRT_SIMULATOR_URL environment variable, ex: http://localhost:45000/simulator')
 
 _useAggregation = true # enable/disable using the aggregation framework
 _profile = false # enable/disable recording method performance to the collection 'profiling'
@@ -297,7 +297,7 @@ findAirportById = (id) ->
   return Airports.findOne({'_id': id})
 
 startSimulation = (simPas, startDate, endDate, origin) ->
-  future = new Future();
+  future = new Future()
   HTTP.post(_FLIRT_SIMULATOR_URL, {
     params: {
       submittedBy: 'robo@noreply.io',
@@ -395,17 +395,42 @@ typeaheadAirport = (search, skip) ->
   if _useAggregation
     pipeline = [
       {$match: {$or: fields}},
-      {$sort: {_id: 1}},
-      {$skip: skip},
-      {$limit: 10}
     ]
     matches = Airports.aggregate(pipeline)
   else
     query = { $or: fields }
-    matches = Airports.find(query, {limit: 10, sort: {_id: 1}, skip: skip, transform: null}).fetch()
+    matches = Airports.find(query, {transform: null}).fetch()
+
+  matches = _floatMatchingAirport(search, matches)
+
+  matches = matches.slice(skip, skip + 10)
   if _profile
     recordProfile('typeaheadAirport', new Date() - start)
   return matches
+
+# moves the airport with a code matching the search term to the beginning of the
+# returned array
+#
+# @param [String] search, the string to search for matches
+# @param [Array] airports, an array of airport documents
+# @return [Array] airports, an array of airport documents searched code first if found
+_floatMatchingAirport = (search, airports) ->
+  exactMatchIndex = null
+  i = 0
+  while i <= airports.length
+    if _.isUndefined(airports[i])
+      i++
+      continue
+    else if airports[i]["_id"].toUpperCase() is search.toUpperCase()
+      exactMatchIndex = i
+      break
+    i++
+  if exactMatchIndex isnt null
+    matchElement = [airports[exactMatchIndex]]
+    airports.splice(exactMatchIndex, 1)
+    airports = matchElement.concat(airports)
+  return airports
+
 # counts the number of airports that match the search
 #
 # @param [String] search, the string to search for matches
@@ -421,7 +446,7 @@ countTypeaheadAirports = (search) ->
     fields.push(field)
 
   query = { $or: fields }
-  count = Airports.find(query, {sort: {_id: 1}, transform: null}).count()
+  count = Airports.find(query, {transform: null}).count()
 
   if _profile
     recordProfile('countTypeaheadAirports', new Date() - start)


### PR DESCRIPTION
- The type-ahead origination search sorts the results by airport code.When searching for `WAS`, or `SEA`, for example, the sorting would put them behind other airports because of alphabetical ordering. This enhancement finds an airport by search code, if it exists and places it at the first position in the array.  
- Searching by Airport code places the matching airport first in the type-ahead search window.
