### PR TITLE
Remove old sidebar from package.js in example

### DIFF
--- a/example/.meteor/packages
+++ b/example/.meteor/packages
@@ -9,7 +9,6 @@ coffeescript
 reactive-var
 reactive-dict
 grits:grits-net-meteor@0.0.1
-grits:flirt-sidebar@0.0.1
 xolvio:cucumber@0.19.4_1
 andrei:tablesorter
 okgrow:analytics

--- a/example/.meteor/versions
+++ b/example/.meteor/versions
@@ -33,7 +33,6 @@ flawless:meteor-toastr@1.0.1
 fortawesome:fontawesome@4.4.0
 fourq:typeahead@1.0.0
 geojson-utils@1.0.4
-grits:flirt-sidebar@0.0.1
 grits:grits-net-meteor@0.0.1
 halunka:i18n@1.1.1
 html-tools@1.0.5


### PR DESCRIPTION
I think this may have been added back when I rebased or was never removed. My bad.
I wonder if we even need the entire `example` folder?
